### PR TITLE
[FIX]: reject when receiving null as argument

### DIFF
--- a/src/promiseAllProperties.ts
+++ b/src/promiseAllProperties.ts
@@ -7,7 +7,7 @@ export type PromisesMap<T> = { [P in keyof T]: Promise<T[P]> | T[P] };
  * @return {Promise<T>}  a promise that resolved to an object with the same properties containing the resolved values
  */
 export default function promiseAllProperties<T>(promisesMap: PromisesMap<T>): Promise<T> {
-  if (typeof promisesMap !== 'object') {
+  if (promisesMap === null || typeof promisesMap !== 'object') {
     return Promise.reject('The input argument must be of type Object');
   }
 

--- a/test/promiseAllProperties.spec.ts
+++ b/test/promiseAllProperties.spec.ts
@@ -8,7 +8,8 @@ const expect = chai.expect;
 describe('promiseAllProperties', () => {
   describe('validation rejections', () => {
     it('should reject if not receiving an object', () => {
-      return expect((promiseAllProperties as any)()).to.be.rejectedWith('The input argument must be of type Object');
+      expect((promiseAllProperties as any)()).to.be.rejectedWith('The input argument must be of type Object');
+      return expect((promiseAllProperties as any)(null)).to.be.rejectedWith('The input argument must be of type Object');
     });
 
     it('should not reject if the input object contains a non promise property', () => {


### PR DESCRIPTION
`null` as input argument passed custom runtime typechecking because `typeof null === 'object'`.