### PR TITLE
[FEAT] Add promiseAllSettledProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # Promise all properties
 [![tests](https://github.com/marcelowa/promise-all-properties/actions/workflows/ci.yaml/badge.svg)](https://github.com/marcelowa/promise-all-properties/actions/workflows/ci.yaml)
 
-A helper function that receives an object with a promise in each property and returns a promise that resolves to an object with the same properties and the resolved values of the promises.  
+A helper function that receives an object with a [Promise] in each property and returns a promise that resolves to an object with the same properties and the resolved values of the promises.  
 
 The returned promise is rejected in the following cases:  
 1. The input argument is not an "object"  
-2. at least one of the promises is rejected  
+2. At least one of the promises are rejected  
+
+[Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
 ## Requirements
-* ES6 Promise supporting javascript engine (browser or Node.js), or at least an ES6 Promise polyfill
-* yarn installed
+* ES6 Promise supporting Javascript engine (browser or Node.js), or at least an ES6 Promise polyfill
+* a node package manager installed (such as NPM or Yarn)
 
 ## Usage example (ES6/Typescript):
+
 ```javascript
 import promiseAllProperties from 'promise-all-properties';
 
@@ -31,6 +34,38 @@ promise.then((resolvedObject) => {
 });
 
 ```
+
+## Promise all settled properties
+
+This helper function works the same as `promiseAllProperties`, except it uses [`Promise.allSettled`][allSettled] instead of [`Promise.all`][all]. It is therefore possible to get the status of all the promises, regardless of how many of them were fulfilled or rejected.
+
+Usage example:
+
+```javascript
+import {promiseAllSettledProperties} from 'promise-all-properties';
+
+const promisesObject = {
+  someProperty: Promise.resolve('resolve value'),
+  anotherProperty: Promise.reject(new Error('a rejection')),
+  yetAnotherProperty: Promise.reject(new Error('another rejection')),
+};
+
+const promise = promiseAllSettledProperties(promisesObject);
+
+promise.then((resolvedObject) => {
+  console.log(resolvedObject);
+  // {
+  //   someProperty: {status: 'fulfilled', value: 'resolve value'},
+  //   anotherProperty: {status: 'rejected', reason: Error('a rejection')},
+  //   yetAnotherProperty: {status: 'rejected', reason: Error('another rejection')}
+  // }
+});
+
+// By comparison, promiseAllProperties(promisesObject) would reject with Error('a rejection')
+```
+
+[allSettled]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled
+[all]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all
 
 ## Breaking changes
 

--- a/src/promiseAllProperties.ts
+++ b/src/promiseAllProperties.ts
@@ -2,36 +2,87 @@ type PlainObj = Record<string, unknown>;
 export type PromisesMap<T extends PlainObj> = {
   [P in keyof T]: Promise<T[P]> | T[P];
 };
+export type PromiseOutcomesMap<T extends PlainObj> = {
+  [P in keyof T]: PromiseSettledResult<T[P]>;
+}
+
+type Keys<T extends PlainObj> = (keyof T)[];
+type Promises<T extends PlainObj> = PromisesMap<T>[keyof T][];
 
 /**
- * Receives an object with promise containing properties and returns a promise that resolves to an object
- * with the same properties containing the resolved values
- * @param  {PromisesMap<T>} promisesMap  the input object with a promise in each property
+ * Receives an object with promises or values as properties and returns a promise that resolves to an object
+ * with the same properties containing the resolved values.
+ *
+ * If any of the given promises are rejected, the resulting promise is rejected with the reason set to that
+ * of the promise that was rejected first.
+ *
+ * @param  {PromisesMap<T>} promisesMap  the input object with a promise or value in each property
+ * @template T the type of the input object, but with all properties having been awaited
  * @return {Promise<T>}  a promise that resolved to an object with the same properties containing the resolved values
+ * @see Promise.all
  */
 export default function promiseAllProperties<T extends PlainObj>(
   promisesMap: PromisesMap<T>
 ): Promise<T> {
-	if (
-		!(typeof process !== undefined && process.env.NODE_ENV === 'production') &&
-		(promisesMap === null ||
-			typeof promisesMap !== 'object' ||
-			Array.isArray(promisesMap))
-	) {
-		return Promise.reject(new TypeError('The input argument must be a plain object'));
-	}
+  if (!isProduction() && !isValidPromisesMap(promisesMap)) {
+    return Promise.reject(new TypeError('The input argument must be a plain object'));
+  }
 
-  const keys = Object.keys(promisesMap);
-  const promises = keys.map((key) => {
-    return (promisesMap as any)[key];
-  });
+  const [keys, promises] = extractKeysAndPromises(promisesMap);
 
-  return Promise.all(promises).then(results => {
-    return results.reduce((resolved, result, index) => {
-      resolved[keys[index]] = result;
-      return resolved;
-    }, {});
-  });
+  return Promise.all(promises)
+    .then(results => reassembleResultsAsMap(keys, results) as T);
 }
 
-export { promiseAllProperties };
+/**
+ * Receives an object with promises or values as properties and returns a promise that resolves to an object
+ * with the same properties containing the outcome of each promise.
+ *
+ * If any of the given promises are rejected, the resulting promise will still resolve. This lets you
+ * inspect the results and report on all rejected promises and not just the first one.
+ *
+ * @param promisesMap the input object with a promise or value in each property
+ * @template T the type of the input object, but with all properties having been awaited
+ * @return a promise that resolves to an object with the same properties containing the outcomes
+ * @see Promise.allSettled
+ */
+function promiseAllSettledProperties<T extends PlainObj>(
+  promisesMap: PromisesMap<T>
+): Promise<PromiseOutcomesMap<T>> {
+  if (!isProduction() && !isValidPromisesMap(promisesMap)) {
+    return Promise.reject(new TypeError('The input argument must be a plain object'));
+  }
+
+  const [keys, promises] = extractKeysAndPromises(promisesMap);
+
+  return Promise.allSettled(promises)
+    .then(results => reassembleResultsAsMap(keys, results) as PromiseOutcomesMap<T>);
+}
+
+function isProduction(): boolean {
+  return typeof process !== undefined && process.env.NODE_ENV === 'production';
+}
+
+function isValidPromisesMap(promisesMap: unknown): promisesMap is PromisesMap<PlainObj> {
+  return promisesMap != null && typeof promisesMap === 'object' && !Array.isArray(promisesMap);
+}
+
+function extractKeysAndPromises<T extends PlainObj>(promisesMap: PromisesMap<T>): [Keys<T>, Promises<T>] {
+  const keys: (keyof T)[] = Object.keys(promisesMap);
+  const promises = keys.map((key) => promisesMap[key]);
+  return [keys, promises];
+}
+
+function reassembleResultsAsMap<T extends PlainObj, R>(keys: Keys<T>, results: R[]): Record<keyof T, R> {
+  const reassembled: Partial<Record<keyof T, R>> = {};
+  results.forEach((result, index) => {
+    const correspondingKey = keys[index];
+    reassembled[correspondingKey] = result;
+  });
+  // We know all keys of T have a value now, so remove Partial<>
+  return reassembled as Record<keyof T, R>;
+  // We are unable to associate each key of T with the specific type for that key,
+  // so the caller must cast the result to the appropriate type
+}
+
+export {promiseAllProperties, promiseAllSettledProperties};

--- a/test/promiseAllProperties.spec.ts
+++ b/test/promiseAllProperties.spec.ts
@@ -1,6 +1,6 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import promiseAllProperties from '../src/promiseAllProperties';
+import promiseAllProperties, {promiseAllSettledProperties} from '../src/promiseAllProperties';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -30,7 +30,7 @@ describe('promiseAllProperties', () => {
 
     it('should not reject if the input object contains a non promise property', () => {
       return expect(promiseAllProperties({x: 1})).to.eventually.contain({
-          x: 1,
+        x: 1,
       });
     });
 
@@ -49,26 +49,181 @@ describe('promiseAllProperties', () => {
   describe('input with promises that should resolve', () => {
     it('should resolve to an object with resolved values instead', () => {
       const promisesObject = {
-        firstPromise : Promise.resolve('result of first promise'),
-        secondPromise : Promise.resolve('result of second promise'),
+        firstPromise: Promise.resolve('result of first promise'),
+        secondPromise: Promise.resolve('result of second promise'),
       };
       const promise = promiseAllProperties(promisesObject);
       return expect(promise).to.eventually.contain({
-          firstPromise : 'result of first promise',
-          secondPromise : 'result of second promise',
+        firstPromise: 'result of first promise',
+        secondPromise: 'result of second promise',
       });
     });
-  });
 
-  describe('input with promises that should resolve', () => {
     it('should be rejected if at least one of the promises is rejected', () => {
       const promisesObject = {
-        firstPromise : Promise.resolve('result of first promise'),
-        secondPromise : Promise.reject('error in the second promise'),
+        firstPromise: Promise.resolve('result of first promise'),
+        secondPromise: Promise.reject('error in the second promise'),
       };
       const promise = promiseAllProperties(promisesObject);
       return expect(promise).to.be.rejectedWith('error in the second promise');
     });
   });
 
+  describe('the typing', () => {
+    type ExpectedType = Promise<{
+      myString: string,
+      myLiteral: 'a literal',
+      myNumber: number,
+      myBoolean: boolean,
+    }>;
+
+    it('returns the expected type', () => {
+      let expectedType: ExpectedType;
+
+      let result = promiseAllProperties({
+        myString: Promise.resolve('a string'),
+        myLiteral: Promise.resolve('a literal' as const),
+        myNumber: Promise.resolve(1234),
+        myBoolean: true,
+      });
+
+      expectedType = result;
+      result = expectedType;
+    });
+
+    it('fails typechecking if a promise type is wrong', () => {
+      // @ts-expect-error
+      const result: ExpectedType = promiseAllProperties({
+        myString: Promise.resolve(1234),  // should have been string
+        myLiteral: Promise.resolve('a literal' as const),
+        myNumber: Promise.resolve(1234),
+        myBoolean: true,
+      });
+    });
+  });
+});
+
+describe('promiseAllSettledProperties', () => {
+  describe('validate rejections', () => {
+    it('should reject if not receiving an object', () => {
+      const promises = [
+        // @ts-expect-error  (testing bad input)
+        promiseAllSettledProperties(/*undefined*/),
+        // @ts-expect-error  (testing bad input)
+        promiseAllSettledProperties(null),
+        // @ts-expect-error  (testing bad input)
+        promiseAllSettledProperties('string'),
+        // @ts-expect-error  (testing bad input)
+        promiseAllSettledProperties(123),
+        // @ts-expect-error  (testing bad input)
+        promiseAllSettledProperties(true),
+        // @ts-expect-error  (testing bad input)
+        promiseAllSettledProperties([Promise.resolve(1)]),
+      ].map((promise) =>
+        expect(promise).to.be.rejectedWith(TypeError, 'The input argument must be a plain object')
+      );
+
+      return Promise.all(promises);
+    });
+
+    it('should not reject if the input object contains a non promise property', () => {
+      return expect(promiseAllSettledProperties({x: 1})).to.eventually.deep.equal({x: {status: 'fulfilled', value: 1}});
+    });
+  });
+
+  describe('the input is an empty object', () => {
+    it('should return a promise', () => {
+      expect(promiseAllSettledProperties({})).to.be.instanceOf(Promise);
+    });
+
+    it('should return a promise that resolves to an object', () => {
+      return expect(promiseAllSettledProperties({})).to.eventually.be.an('object');
+    });
+  });
+
+  describe('input with promises', () => {
+    it('should resolve to an object with the result of each promise', () => {
+      const firstRejection = new TypeError('Rejection 1');
+      const secondRejection = new Error('Rejection 2');
+      const promisesObject = {
+        firstPromise: Promise.resolve('result of first promise'),
+        secondPromise: Promise.resolve('result of second promise'),
+        thirdPromise: Promise.reject(firstRejection),
+        fourthPromise: Promise.reject(secondRejection),
+      };
+      const promise = promiseAllSettledProperties(promisesObject);
+      return expect(promise).to.eventually.deep.equal({
+        firstPromise: {status: 'fulfilled', value: 'result of first promise'},
+        secondPromise: {status: 'fulfilled', value: 'result of second promise'},
+        thirdPromise: {status: 'rejected', reason: firstRejection},
+        fourthPromise: {status: 'rejected', reason: secondRejection},
+      });
+    });
+  });
+
+  describe('the typing', () => {
+    type RejectedOutcome = {
+      status: 'rejected',
+      reason: any,
+    };
+    type ExpectedType = Promise<{
+      myString: {
+        status: 'fulfilled',
+        value: string,
+      } | RejectedOutcome,
+      myLiteral: {
+        status: 'fulfilled',
+        value: 'a literal',
+      } | RejectedOutcome,
+      myNumber: {
+        status: 'fulfilled',
+        value: number,
+      } | RejectedOutcome,
+      myBoolean: {
+        status: 'fulfilled',
+        value: boolean,
+      } | RejectedOutcome,
+      myRejection: {
+        status: 'fulfilled',
+        value: never,
+      } | RejectedOutcome,
+    }>;
+
+    it('returns the expected type', () => {
+      let expectedType: ExpectedType;
+
+      let result = promiseAllSettledProperties({
+        myString: Promise.resolve('a string'),
+        myLiteral: Promise.resolve('a literal' as const),
+        myNumber: Promise.resolve(1234),
+        myBoolean: true,
+        myRejection: Promise.reject(new Error('Rejected')),
+      });
+
+      expectedType = result;
+      result = expectedType;
+    });
+
+    it('fails typechecking if a promise type is wrong', () => {
+      // @ts-expect-error
+      const result1: ExpectedType = promiseAllSettledProperties({
+        myString: Promise.resolve(1234),  // should have been string
+        myLiteral: Promise.resolve('a literal' as const),
+        myNumber: Promise.resolve(1234),
+        myBoolean: true,
+        myRejection: Promise.reject(new Error('Rejected')),
+      });
+    });
+
+    it('fails typechecking if a non-promise type is wrong', () => {
+      // @ts-expect-error
+      const result2: ExpectedType = promiseAllSettledProperties({
+        myString: Promise.resolve('a string'),
+        myLiteral: Promise.resolve('a literal' as const),
+        myNumber: Promise.resolve(1234),
+        myBoolean: 'true-ish',  // should have been boolean
+        myRejection: Promise.reject(new Error('Rejected')),
+      });
+    });
+  });
 });


### PR DESCRIPTION
Add support for `promiseAllSettledProperties` for the times where you need to know the results of all the promises, even if one or more of them were rejected.

I was unable to figure out how to generalize the implementations within TypeScript's constraints, so I opted to extract the common tasks into helper functions instead and have some repetition between the two functions. I managed to keep type-checking enabled for a greater portion of the implementation, but I was unable to find a way of expressing the transformation from object to arrays and back in such a way that the specific type of each key was kept automatically. So I had to use casts for the final return values.

I added tests for `promiseAllSettledProperties` similar to the existing ones for `promiseAllProperties`, but I also added some type tests to both. They should always succeed at runtime, but they are exercised by the type checker to ensure that the functions' type signatures work correctly.

I'm a little unsure of the name `promiseAllSettledProperties`, but it follows the naming scheme.

Feel free to make changes as you see fit.

Resolves #16 